### PR TITLE
Reduce permission requirements

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -18,9 +18,7 @@
         "default_title": "__MSG_enable__"
     },
     "permissions": [
-        "file:///*",
-        "http://*/",
-        "https://*/"
+        "activeTab",
     ],
     "background": {
         "scripts": ["background.js"],


### PR DESCRIPTION
- Replace always-on host permissions with the single "activeTab" permission, which only gives the add-on access to page content when needed (i.e. when its button is clicked)